### PR TITLE
Sampling refactor

### DIFF
--- a/VideoBarcode/VideoBarcode/ColorHelp.cs
+++ b/VideoBarcode/VideoBarcode/ColorHelp.cs
@@ -1,32 +1,26 @@
 ﻿namespace VideoBarcode;
 
-public static class ColorHelp
+internal static class ColorHelp
 {
     /*
      * RGB->HSV and HSV->RGB functions adapted from https://www.cs.rit.edu/~ncs/color/t_convert.html
      */
-
-    public static void RGBtoHSV(float r, float g, float b, out float h, out float s, out float v)
+    internal static (float H, float S, float V) RGBtoHSV(float r, float g, float b)
     {
-        float min, max, delta;
-        min = Math.Min(r, Math.Min(g, b));
-        max = Math.Max(r, Math.Max(g, b));
+        float min = Math.Min(r, Math.Min(g, b));
+        float max = Math.Max(r, Math.Max(g, b));
 
-        v = max;
-        delta = max - min;
-
-        if (max != 0)
-        {
-            s = delta / max;
-        }
-        else
+        float v = max;
+        if (max == 0)
         {
             // r = g = b = 0		// s = 0, v is undefined
-            s = 0;
-            h = 0;
-            return;
+            return (0, 0, 0);
         }
 
+        float delta = max - min;
+        float s = delta / max;
+
+        float h;
         if (r == max)
         {
             // between yellow & magenta
@@ -54,29 +48,30 @@ public static class ColorHelp
         {
             h = 0;
         }
+
+        return (h, s, v);
     }
 
-    public static void HSVtoRGB(out float r, out float g, out float b, float h, float s, float v)
+    internal static (float R, float G, float B) HSVtoRGB(float h, float s, float v)
     {
-        int i;
-        float f, p, q, t;
+        float r, g, b;
 
         if (s == 0)
         {
             // achromatic (grey)
             r = g = b = v;
-            return;
+            return (r, g, b);
         }
 
         // sector 0 to 5
         h /= 60;
-        i = (int)Math.Floor(h);
+        int i = (int)Math.Floor(h);
 
         // factorial part of h
-        f = h - i;
-        p = v * (1 - s);
-        q = v * (1 - s * f);
-        t = v * (1 - s * (1 - f));
+        float f = h - i;
+        float p = v * (1 - s);
+        float q = v * (1 - s * f);
+        float t = v * (1 - s * (1 - f));
 
         switch (i)
         {
@@ -111,5 +106,7 @@ public static class ColorHelp
                 b = q;
                 break;
         }
+
+        return (r, g, b);
     }
 }

--- a/VideoBarcode/VideoBarcode/FrameColorData.cs
+++ b/VideoBarcode/VideoBarcode/FrameColorData.cs
@@ -1,0 +1,38 @@
+﻿using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.PixelFormats;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace VideoBarcode;
+
+internal class FrameColorData
+{
+    [JsonPropertyName("P")]
+    public uint PackedBgra32 { get; set; }
+
+    [JsonPropertyName("T")]
+    public int TimestampMillisec { get; set; }
+
+    [JsonIgnore]
+    internal Bgra32 Bgra32 => new() { PackedValue = PackedBgra32 };
+
+    public FrameColorData()
+    {
+
+    }
+
+    internal FrameColorData(Color color, int timestampMsec)
+    {
+        PackedBgra32 = color.ToPixel<Bgra32>().PackedValue;
+        TimestampMillisec = timestampMsec;
+    }
+
+    /// <summary>
+    /// ImageSharp packs colors from LSB to MSB. Bgra32 is 0xARGB, Argb32 is 0xBGRA, Rgba32 is 0xABGR, etc.<br />
+    /// Hence the file convention of Title.argb.uint.json for the packed format of Bgra32.
+    /// </summary>
+    /// <exception cref="InvalidOperationException"></exception>
+    internal static List<FrameColorData> Deserialize(string jsonFilePath)
+        => JsonSerializer.Deserialize<List<FrameColorData>>(File.ReadAllText(jsonFilePath))
+            ?? throw new InvalidOperationException("Failed to deserialize JSON file with color data");
+}

--- a/VideoBarcode/VideoBarcode/Program.cs
+++ b/VideoBarcode/VideoBarcode/Program.cs
@@ -1,216 +1,188 @@
 ﻿using System.Text.Json;
-using System.Text.Json.Serialization;
 using OpenCvSharp;
 using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.Drawing.Processing;
 using SixLabors.ImageSharp.PixelFormats;
 using SixLabors.ImageSharp.Processing;
+using VideoBarcode;
 
-namespace VideoBarcode;
+int sampleMsec = 1000;
 
-class FrameColorData
+string directory = @"/Users/Connor/Desktop/Video Barcode/Her";
+
+string videoFilePath = Path.Combine(directory, "Her (2013).mp4");
+string jsonFilePath = Path.Combine(directory, "Her.argb.uint.json");
+string gradientFilePath = Path.Combine(directory, "Her.png");
+
+if (!File.Exists(videoFilePath))
 {
-    [JsonPropertyName("P")]
-    public uint PackedBgra32 { get; set; }
-
-    [JsonPropertyName("T")]
-    public int TimestampMsec { get; set; }
-
-    [JsonIgnore]
-    internal Bgra32 Bgra32 => new() { PackedValue = PackedBgra32 };
-
-    public FrameColorData()
-    {
-
-    }
-
-    internal FrameColorData(Color color, int timestampMsec)
-    {
-        PackedBgra32 = color.ToPixel<Bgra32>().PackedValue;
-        TimestampMsec = timestampMsec;
-    }
+    throw new FileNotFoundException($"{videoFilePath} not found");
 }
 
-class Program
+// opens the video file (ffmpeg may not be needed as long as the native bindings are available for the platform)
+var capture = new VideoCapture(videoFilePath);
+
+Console.WriteLine($"Processing {Path.GetFileName(videoFilePath)}...");
+Console.WriteLine($"Frame Rate: {capture.Fps} FPS, Sampling every {sampleMsec} ms");
+Console.WriteLine($"Duration: {TimeSpan.FromSeconds(capture.FrameCount / capture.Fps)}");
+
+IReadOnlyList<FrameColorData> averageColors;
+
+// use the JSON file of average colors if it exists, otherwise compute a new list from the capture
+if (File.Exists(jsonFilePath))
 {
-    static void Main(string[] args)
+    averageColors = FrameColorData.Deserialize(jsonFilePath);
+}
+else
+{
+    averageColors = AverageColorsOfCapture(capture, sampleMsec);
+
+    // Serialize the average colors list and write it to a file.
+    // Note that this is the "packed" color format used by ImageSharp, different from the bit-shifted ARGB int that System.Drawing.Color uses.
+    // From MSB to LSB, Bgra32 will be packed into the uint as 0xARGB. LSB to MSB is 0xBGRA, hence the type name.
+    File.WriteAllText(jsonFilePath, JsonSerializer.Serialize(averageColors));
+}
+
+var summarizedColors = SummarizeColorsByTime(averageColors);
+
+WriteHistogram(gradientFilePath, summarizedColors, height: summarizedColors.Count / 4, width: summarizedColors.Count);
+
+Console.WriteLine("\nFinished.");
+
+static IReadOnlyList<FrameColorData> AverageColorsOfCapture(VideoCapture capture, int sampleMsec)
+{
+    int captureLengthSeconds = Convert.ToInt32(capture.FrameCount / capture.Fps);
+
+    // this list represents the average color of every frame of the video
+    var averageColors = new List<FrameColorData>(capacity: captureLengthSeconds + 1);
+
+    // Mat is IDisposable
+    using var image = new Mat<Vec3b>();
+    while (true)
     {
-        int sampleMsec = 1000;
-
-        string directory = @"/Users/Connor/Desktop/Her";
-
-        string videoFilePath = Path.Combine(directory, "Her (2013).mp4");
-        string jsonFilePath = Path.Combine(directory, "Her.argb.uint.json");
-        string gradientFilePath = Path.Combine(directory, "Her.jpg");
-
-        // opens the video file (ffmpeg may not be needed as long as the native bindings are available for the platform)
-        var capture = new VideoCapture(videoFilePath);
-
-        Console.WriteLine($"Processing {Path.GetFileName(videoFilePath)}...");
-        Console.WriteLine($"Frame Rate: {capture.Fps} FPS, Sampling every {sampleMsec} ms");
-        Console.WriteLine($"Duration: {TimeSpan.FromSeconds(capture.FrameCount / capture.Fps)}");
-
-        List<FrameColorData> averageColors;
-
-        // use the JSON file of average colors if it exists, otherwise compute a new list from the capture
-        if (File.Exists(jsonFilePath))
+        capture.Read(image);
+        if (image.Empty())
         {
-            // ImageSharp packs colors from LSB to MSB. Bgra32 is 0xARGB, Argb32 is 0xBGRA, Rgba32 is 0xABGR, etc.
-            // Hence the file convention of Title.argb.uint.json for the packed format of Bgra32
-            averageColors = JsonSerializer.Deserialize<List<FrameColorData>>(File.ReadAllText(jsonFilePath))
-                ?? throw new InvalidOperationException("Failed to deserialize JSON file with color data");
-        }
-        else
-        {
-            if (!File.Exists(videoFilePath))
-            {
-                throw new InvalidOperationException($"{videoFilePath} not found");
-            }
-
-            averageColors = AverageColorsOfCapture(capture, sampleMsec);
-
-            // Serialize the average colors list and write it to a file.
-            // Note that this is the "packed" color format used by ImageSharp, different from the bit-shifted ARGB int that System.Drawing.Color uses.
-            // From MSB to LSB, Bgra32 will be packed into the uint as 0xARGB. LSB to MSB is 0xBGRA, hence the type name.
-            File.WriteAllText(jsonFilePath, JsonSerializer.Serialize(averageColors));
+            break;
         }
 
-        var summarizedColors = SummarizeColorsByTime(averageColors);
+        // read PosMsec here, because advancing the time seems to cause the value to decrease until the next capture.Read() call
+        int timestampMillis = capture.PosMsec;
 
-        WriteHistogram(gradientFilePath, summarizedColors, summarizedColors.Length / 4, summarizedColors.Length);
+        averageColors.Add(new FrameColorData(AverageFrameColorHSV(image), timestampMillis));
 
-        Console.WriteLine("\nFinished.");
+        // advance the time to the next sample
+        capture.PosMsec += sampleMsec;
+
+        // display progress, formatted to two decimal places. \r is a carriage return without a newline to overwrite the previous line
+        float progress = (float)Math.Min(capture.PosFrames, capture.FrameCount) / capture.FrameCount;
+        Console.Write($"\rProgress: {string.Format("{0:0.00}", progress * 100.0)}% {TimeSpan.FromMilliseconds(timestampMillis)}");
     }
 
-    private static List<FrameColorData> AverageColorsOfCapture(VideoCapture capture, int sampleMsec)
+    return averageColors;
+}
+
+static Color AverageFrameColorHSV(Mat<Vec3b> image)
+{
+    // accumulators for hue, saturation, and value
+    int[] hueCounts = new int[360];
+    float[] saturationAccum = new float[360];
+    float[] valueAccum = new float[360];
+
+    int hue;
+    float saturation, value;
+
+    var indexer = image.GetIndexer();
+
+    for (int y = 0; y < image.Height; y++)
     {
-        // this list represents the average color of every frame of the video
-        var averageColors = new List<FrameColorData>();
-
-        var image = new Mat<Vec3b>();
-        while (true)
+        for (int x = 0; x < image.Width; x++)
         {
-            // read one frame for each thread
-            capture.Read(image);
+            Vec3b pixel = indexer[y, x];
+            var (h, s, v) = ColorHelp.RGBtoHSV(pixel.Item2, pixel.Item1, pixel.Item0);
 
-            if (image.Empty())
-            {
-                break;
-            }
+            // Use cast instead of Convert because Convert will round up to 360 (out of bounds)
+            hue = (int)h;
 
-            averageColors.Add(new FrameColorData(AverageFrameColorHSV(image), capture.PosMsec));
-
-            capture.PosMsec += sampleMsec;
-
-            // display progress, formatted to two decimal places
-            float progress = (float)Math.Min(capture.PosFrames, capture.FrameCount) / capture.FrameCount;
-            Console.Write($"\rProgress: {string.Format("{0:0.00}", progress * 100.0)}% {TimeSpan.FromMilliseconds(capture.PosMsec)}");
+            hueCounts[hue] += 1;
+            saturationAccum[hue] += s;
+            valueAccum[hue] += v;
         }
-
-        return averageColors;
     }
 
-    private static Color AverageFrameColorHSV(Mat<Vec3b> image)
+    // smooth out the hue array by adding neigboring hues
+    var smoothHueCounts = SmoothArray(hueCounts, factor: 10);
+
+    // compute the average hue, saturation, and value
+    hue = Array.IndexOf(smoothHueCounts, smoothHueCounts.Max());
+    saturation = saturationAccum[hue] / hueCounts[hue];
+    value = valueAccum[hue] / hueCounts[hue];
+
+    if (double.IsNaN(saturation))
     {
-        // accumulators for hue, saturation, and value
-        var hueCounts = new int[360];
-        var saturationAccum = new float[360];
-        var valueAccum = new float[360];
-
-        int hue;
-        float saturation, value;
-
-        var indexer = image.GetIndexer();
-
-        for (int y = 0; y < image.Height; y++)
-        {
-            for (int x = 0; x < image.Width; x++)
-            {
-                Vec3b pixel = indexer[y, x];
-
-                // var color = Color.FromArgb(pixel.Item2, pixel.Item1, pixel.Item0);
-                // ColorHelp.ColorToHSV(color, out double dHue, out saturation, out value);
-
-                ColorHelp.RGBtoHSV(pixel.Item2, pixel.Item1, pixel.Item0, out float h, out float s, out float v);
-
-                // Use cast instead of Convert because Convert will round up to 360 (out of bounds)
-                hue = (int)h;
-
-                hueCounts[hue] += 1;
-                saturationAccum[hue] += s;
-                valueAccum[hue] += v;
-            }
-        }
-
-        // smooth out the hue array by adding neigboring hues
-        var smoothHueCounts = SmoothArray(hueCounts, 10);
-
-        // compute the average hue, saturation, and value
-        hue = Array.IndexOf(smoothHueCounts, smoothHueCounts.Max());
-        saturation = saturationAccum[hue] / hueCounts[hue];
-        value = valueAccum[hue] / hueCounts[hue];
-
-        if (double.IsNaN(saturation))
-        {
-            saturation = 0;
-        }
-
-        if (double.IsNaN(value))
-        {
-            value = 0;
-        }
-
-        ColorHelp.HSVtoRGB(out float r, out float g, out float b, hue, saturation, value);
-        return Color.FromRgb((byte)r, (byte)g, (byte)b);
+        saturation = 0;
     }
 
-    private static int[] SmoothArray(int[] inputArr, int factor)
+    if (double.IsNaN(value))
     {
-        var outputArr = new int[inputArr.Length];
-
-        for (int i = 0; i < inputArr.Length; i++)
-        {
-            int start = Math.Max(0, i - factor);
-            int end = Math.Min(inputArr.Length - 1, i + factor);
-
-            outputArr[i] = inputArr.Skip(start).Take(end - start + 1).Sum();
-        }
-
-        return outputArr;
+        value = 0;
     }
 
-    private static Color[] SummarizeColorsByTime(List<FrameColorData> frameData)
+    var (r, g, b) = ColorHelp.HSVtoRGB(hue, saturation, value);
+    return Color.FromRgb((byte)r, (byte)g, (byte)b);
+}
+
+static int[] SmoothArray(int[] inputArr, int factor)
+{
+    var outputArr = new int[inputArr.Length];
+
+    for (int i = 0; i < inputArr.Length; i++)
     {
-        int totalFrames = frameData.Count;
-        int numGroups = (frameData.Last().TimestampMsec / 1_000) + 1;
+        int startIdx = Math.Max(0, i - factor);
+        int end = Math.Min(inputArr.Length - 1, i + factor);
 
-        var colorGroups = Enumerable.Range(0, numGroups).Select(_ => new List<Bgra32>()).ToArray();
-
-        foreach (FrameColorData entry in frameData)
-        {
-            int second = entry.TimestampMsec / 1_000;
-            colorGroups[second].Add(entry.Bgra32);
-        }
-
-        return colorGroups.Select(g =>
-        {
-            byte averageRed = Convert.ToByte(g.Average(c => c.R));
-            byte averageGreen = Convert.ToByte(g.Average(c => c.G));
-            byte averageBlue = Convert.ToByte(g.Average(c => c.B));
-
-            return Color.FromRgb(averageRed, averageGreen, averageBlue);
-        }).ToArray();
+        outputArr[i] = inputArr.Skip(startIdx).Take(end - startIdx + 1).Sum();
     }
 
-    private static void WriteHistogram(string gradientFilePath, Color[] colors, int height, int width)
-    {
-        using Image image = new Image<Bgra32>(width, height);
+    return outputArr;
+}
 
-        for (int i = 0; i < colors.Length; i++)
+static IReadOnlyList<Color> SummarizeColorsByTime(IReadOnlyList<FrameColorData> frameData)
+{
+    int totalFrames = frameData.Count;
+    int numGroups = (frameData.Last().TimestampMillisec / 1_000) + 1;
+
+    var colorGroups = Enumerable.Range(0, numGroups).Select(_ => new List<Bgra32>()).ToList();
+
+    foreach (FrameColorData entry in frameData)
+    {
+        int second = entry.TimestampMillisec / 1_000;
+        colorGroups[second].Add(entry.Bgra32);
+    }
+
+    return colorGroups.Select(g =>
+    {
+        if (g.Count == 0)
         {
-            image.Mutate(ctx => ctx.Fill(colors[i], new Rectangle(x: i, y: 0, width: 1, height: height)));
+            return Color.Black;
         }
 
-        image.SaveAsJpeg(gradientFilePath);
+        byte averageRed = Convert.ToByte(g.Average(c => c.R));
+        byte averageGreen = Convert.ToByte(g.Average(c => c.G));
+        byte averageBlue = Convert.ToByte(g.Average(c => c.B));
+
+        return Color.FromRgb(averageRed, averageGreen, averageBlue);
+    }).ToList();
+}
+
+static void WriteHistogram(string gradientFilePath, IReadOnlyList<Color> colors, int height, int width)
+{
+    using Image image = new Image<Bgra32>(width, height);
+
+    for (int i = 0; i < colors.Count; i++)
+    {
+        image.Mutate(ctx => ctx.Fill(colors[i], new Rectangle(x: i, y: 0, width: 1, height: height)));
     }
+
+    image.SaveAsPng(gradientFilePath);
 }

--- a/VideoBarcode/VideoBarcode/Program.cs
+++ b/VideoBarcode/VideoBarcode/Program.cs
@@ -1,4 +1,5 @@
 ﻿using System.Text.Json;
+using System.Text.Json.Serialization;
 using OpenCvSharp;
 using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.Drawing.Processing;
@@ -7,10 +8,35 @@ using SixLabors.ImageSharp.Processing;
 
 namespace VideoBarcode;
 
+class FrameColorData
+{
+    [JsonPropertyName("P")]
+    public uint PackedBgra32 { get; set; }
+
+    [JsonPropertyName("T")]
+    public int TimestampMsec { get; set; }
+
+    [JsonIgnore]
+    internal Bgra32 Bgra32 => new() { PackedValue = PackedBgra32 };
+
+    public FrameColorData()
+    {
+
+    }
+
+    internal FrameColorData(Color color, int timestampMsec)
+    {
+        PackedBgra32 = color.ToPixel<Bgra32>().PackedValue;
+        TimestampMsec = timestampMsec;
+    }
+}
+
 class Program
 {
     static void Main(string[] args)
     {
+        int sampleMsec = 1000;
+
         string directory = @"/Users/Connor/Desktop/Her";
 
         string videoFilePath = Path.Combine(directory, "Her (2013).mp4");
@@ -21,17 +47,17 @@ class Program
         var capture = new VideoCapture(videoFilePath);
 
         Console.WriteLine($"Processing {Path.GetFileName(videoFilePath)}...");
+        Console.WriteLine($"Frame Rate: {capture.Fps} FPS, Sampling every {sampleMsec} ms");
         Console.WriteLine($"Duration: {TimeSpan.FromSeconds(capture.FrameCount / capture.Fps)}");
 
-        List<Color> averageColors;
+        List<FrameColorData> averageColors;
 
         // use the JSON file of average colors if it exists, otherwise compute a new list from the capture
         if (File.Exists(jsonFilePath))
         {
             // ImageSharp packs colors from LSB to MSB. Bgra32 is 0xARGB, Argb32 is 0xBGRA, Rgba32 is 0xABGR, etc.
             // Hence the file convention of Title.argb.uint.json for the packed format of Bgra32
-            averageColors = JsonSerializer.Deserialize<List<uint>>(File.ReadAllText(jsonFilePath))
-                ?.Select(u => new Color(new Bgra32 { PackedValue = u })).ToList()
+            averageColors = JsonSerializer.Deserialize<List<FrameColorData>>(File.ReadAllText(jsonFilePath))
                 ?? throw new InvalidOperationException("Failed to deserialize JSON file with color data");
         }
         else
@@ -41,129 +67,101 @@ class Program
                 throw new InvalidOperationException($"{videoFilePath} not found");
             }
 
-            averageColors = AverageColorsOfCapture(capture);
+            averageColors = AverageColorsOfCapture(capture, sampleMsec);
 
             // Serialize the average colors list and write it to a file.
             // Note that this is the "packed" color format used by ImageSharp, different from the bit-shifted ARGB int that System.Drawing.Color uses.
             // From MSB to LSB, Bgra32 will be packed into the uint as 0xARGB. LSB to MSB is 0xBGRA, hence the type name.
-            File.WriteAllText(jsonFilePath, JsonSerializer.Serialize(averageColors.Select(c => c.ToPixel<Bgra32>().PackedValue).ToArray()));
+            File.WriteAllText(jsonFilePath, JsonSerializer.Serialize(averageColors));
         }
 
-        var summarizedColors = SummarizeColorsByTime(averageColors, Convert.ToInt32(Math.Round(capture.Fps)));
+        var summarizedColors = SummarizeColorsByTime(averageColors);
 
         WriteHistogram(gradientFilePath, summarizedColors, summarizedColors.Length / 4, summarizedColors.Length);
 
         Console.WriteLine("\nFinished.");
     }
 
-    private static List<Color> AverageColorsOfCapture(VideoCapture capture)
+    private static List<FrameColorData> AverageColorsOfCapture(VideoCapture capture, int sampleMsec)
     {
         // this list represents the average color of every frame of the video
-        var averageColors = new List<Color>();
+        var averageColors = new List<FrameColorData>();
 
-        // frame image buffers
-        var images = new Mat<Vec3b>[Environment.ProcessorCount].Select(i => new Mat<Vec3b>()).ToArray();
-
-        int frameIdx = 0;
-        bool finished = false;
-
-        // the list of tasks to find the average color of a frame, one for each logical processor
-        var tasks = new List<Task<Color>>();
-
+        var image = new Mat<Vec3b>();
         while (true)
         {
             // read one frame for each thread
-            for (int i = 0; i < Environment.ProcessorCount; i++)
-            {
-                capture.Read(images[i]);
+            capture.Read(image);
 
-                if (images[i].Empty())
-                {
-                    finished = true;
-                    break;
-                }
-
-                tasks.Add(AverageFrameColorHSV(images[i]));
-
-                frameIdx++;
-            }
-
-            // schedule all of the average frame color tasks
-            Task.WaitAll([.. tasks]);
-
-            // add the results to the running list of average colors
-            averageColors.AddRange(tasks.Select(t => t.Result));
-
-            if (finished)
+            if (image.Empty())
             {
                 break;
             }
 
-            // display progress, formatted to two decimal places
-            float progress = (float)frameIdx / capture.FrameCount;
-            Console.Write($"\rProgress: {string.Format("{0:0.00}", progress * 100.0)}%");
+            averageColors.Add(new FrameColorData(AverageFrameColorHSV(image), capture.PosMsec));
 
-            tasks.Clear();
+            capture.PosMsec += sampleMsec;
+
+            // display progress, formatted to two decimal places
+            float progress = (float)Math.Min(capture.PosFrames, capture.FrameCount) / capture.FrameCount;
+            Console.Write($"\rProgress: {string.Format("{0:0.00}", progress * 100.0)}% {TimeSpan.FromMilliseconds(capture.PosMsec)}");
         }
 
         return averageColors;
     }
 
-    private static Task<Color> AverageFrameColorHSV(Mat<Vec3b> image)
+    private static Color AverageFrameColorHSV(Mat<Vec3b> image)
     {
-        return Task.Run(() =>
+        // accumulators for hue, saturation, and value
+        var hueCounts = new int[360];
+        var saturationAccum = new float[360];
+        var valueAccum = new float[360];
+
+        int hue;
+        float saturation, value;
+
+        var indexer = image.GetIndexer();
+
+        for (int y = 0; y < image.Height; y++)
         {
-            // accumulators for hue, saturation, and value
-            var hueCounts = new int[360];
-            var saturationAccum = new float[360];
-            var valueAccum = new float[360];
-
-            int hue;
-            float saturation, value;
-
-            var indexer = image.GetIndexer();
-
-            for (int y = 0; y < image.Height; y++)
+            for (int x = 0; x < image.Width; x++)
             {
-                for (int x = 0; x < image.Width; x++)
-                {
-                    Vec3b pixel = indexer[y, x];
+                Vec3b pixel = indexer[y, x];
 
-                    // var color = Color.FromArgb(pixel.Item2, pixel.Item1, pixel.Item0);
-                    // ColorHelp.ColorToHSV(color, out double dHue, out saturation, out value);
+                // var color = Color.FromArgb(pixel.Item2, pixel.Item1, pixel.Item0);
+                // ColorHelp.ColorToHSV(color, out double dHue, out saturation, out value);
 
-                    ColorHelp.RGBtoHSV(pixel.Item2, pixel.Item1, pixel.Item0, out float h, out float s, out float v);
+                ColorHelp.RGBtoHSV(pixel.Item2, pixel.Item1, pixel.Item0, out float h, out float s, out float v);
 
-                    // Use cast instead of Convert because Convert will round up to 360 (out of bounds)
-                    hue = (int)h;
+                // Use cast instead of Convert because Convert will round up to 360 (out of bounds)
+                hue = (int)h;
 
-                    hueCounts[hue] += 1;
-                    saturationAccum[hue] += s;
-                    valueAccum[hue] += v;
-                }
+                hueCounts[hue] += 1;
+                saturationAccum[hue] += s;
+                valueAccum[hue] += v;
             }
+        }
 
-            // smooth out the hue array by adding neigboring hues
-            var smoothHueCounts = SmoothArray(hueCounts, 10);
+        // smooth out the hue array by adding neigboring hues
+        var smoothHueCounts = SmoothArray(hueCounts, 10);
 
-            // compute the average hue, saturation, and value
-            hue = Array.IndexOf(smoothHueCounts, smoothHueCounts.Max());
-            saturation = saturationAccum[hue] / hueCounts[hue];
-            value = valueAccum[hue] / hueCounts[hue];
+        // compute the average hue, saturation, and value
+        hue = Array.IndexOf(smoothHueCounts, smoothHueCounts.Max());
+        saturation = saturationAccum[hue] / hueCounts[hue];
+        value = valueAccum[hue] / hueCounts[hue];
 
-            if (double.IsNaN(saturation))
-            {
-                saturation = 0;
-            }
+        if (double.IsNaN(saturation))
+        {
+            saturation = 0;
+        }
 
-            if (double.IsNaN(value))
-            {
-                value = 0;
-            }
+        if (double.IsNaN(value))
+        {
+            value = 0;
+        }
 
-            ColorHelp.HSVtoRGB(out float r, out float g, out float b, hue, saturation, value);
-            return Color.FromRgb((byte)r, (byte)g, (byte)b);
-        });
+        ColorHelp.HSVtoRGB(out float r, out float g, out float b, hue, saturation, value);
+        return Color.FromRgb((byte)r, (byte)g, (byte)b);
     }
 
     private static int[] SmoothArray(int[] inputArr, int factor)
@@ -181,16 +179,17 @@ class Program
         return outputArr;
     }
 
-    private static Color[] SummarizeColorsByTime(List<Color> colors, int fps)
+    private static Color[] SummarizeColorsByTime(List<FrameColorData> frameData)
     {
-        int totalFrames = colors.Count;
-        int numGroups = Convert.ToInt32(Math.Ceiling((double)totalFrames / fps));
+        int totalFrames = frameData.Count;
+        int numGroups = (frameData.Last().TimestampMsec / 1_000) + 1;
 
-        var colorGroups = new List<Bgra32>[numGroups].Select(s => new List<Bgra32>()).ToArray();
+        var colorGroups = Enumerable.Range(0, numGroups).Select(_ => new List<Bgra32>()).ToArray();
 
-        for (int i = 0; i < totalFrames; i++)
+        foreach (FrameColorData entry in frameData)
         {
-            colorGroups[i / fps].Add(colors[i].ToPixel<Bgra32>());
+            int second = entry.TimestampMsec / 1_000;
+            colorGroups[second].Add(entry.Bgra32);
         }
 
         return colorGroups.Select(g =>


### PR DESCRIPTION
Instead of processing every single frame of the video in parallel, sample one frame from each second and average the HSV pixel values inline. This significantly reduces CPU usage and results in a very similar output to the previous method.

This also includes some small readability and performance improvements.